### PR TITLE
Added test coverage for the build and serve methods of the Bundler service.

### DIFF
--- a/src/BundlerInterface.php
+++ b/src/BundlerInterface.php
@@ -17,15 +17,24 @@ interface BundlerInterface {
   public function build();
 
   /**
-   * Start the dev server.
+   * Starts the dev server.
    *
-   * @param $port
-   * @return mixed
+   * This method never returns, it can only throw exceptions. $customListener
+   * can be used to parse the output.
+   *
+   * @param int $port
+   *   Local port to start the dev server on. Defaults to 1234.
+   * @param null|callable $customListener
+   *   Callback that will be passed to \Symfony\Process\Process::wait().
+   * @param int|NULL $timeout
+   *   Timeout in seconds.
    *
    * @throws \Drupal\webpack\WebpackConfigNotValidException
    * @throws \Drupal\webpack\WebpackConfigWriteException
+   * @throws \Drupal\npm\Exception\NpmCommandFailedException
+   * @throws \RuntimeException
    */
-  public function serve($port = '8080');
+  public function serve($port = 1234, $customListener = NULL, $timeout = NULL);
 
   /**
    * Returns the bundle mapping from the state or config.

--- a/src/LibrariesInspectorInterface.php
+++ b/src/LibrariesInspectorInterface.php
@@ -5,14 +5,14 @@ namespace Drupal\webpack;
 interface LibrariesInspectorInterface {
 
   /**
-   * Returns all the libraries defined by enabled modules and themes.
+   * Returns an array of js files that should be treated with webpack.
    *
    * @return array
    */
-  public function getAllLibraries();
+  public function getEntryPoints();
 
   /**
-   * Return a library by name.
+   * Returns a library by name.
    *
    * @param string $extension
    * @param string $name

--- a/src/WebpackConfigBuilder.php
+++ b/src/WebpackConfigBuilder.php
@@ -83,7 +83,7 @@ class WebpackConfigBuilder implements WebpackConfigBuilderInterface {
       //      extensions: ['*', '.js', '.jsx']
       //  },
     ];
-    foreach ($this->getEntryPoints() as $id => $path) {
+    foreach ($this->librariesInspector->getEntryPoints() as $id => $path) {
       $config['entry'][$id] = DRUPAL_ROOT . '/' . $path;
     }
 
@@ -142,30 +142,6 @@ class WebpackConfigBuilder implements WebpackConfigBuilderInterface {
       return false;
     }
     return $outputDir;
-  }
-
-  /**
-   * Returns an array of js files that should be treated with webpack.
-   *
-   * @return array
-   */
-  protected function getEntryPoints() {
-    $entryPoints = [];
-    foreach ($this->librariesInspector->getAllLibraries() as $extension => $libraries) {
-      foreach ($libraries as $libraryName => $library) {
-        if (!$this->librariesInspector->isWebpackLib($library)) {
-          continue;
-        }
-
-        foreach ($library['js'] as $jsAssetInfo) {
-          $path = $jsAssetInfo['data'];
-          $id = $this->librariesInspector->getJsFileId("$extension/$libraryName", $path);
-          $entryPoints[$id] = $path;
-        }
-      }
-    }
-
-    return $entryPoints;
   }
 
   /**

--- a/src/WebpackConfigBuilderInterface.php
+++ b/src/WebpackConfigBuilderInterface.php
@@ -23,6 +23,7 @@ interface WebpackConfigBuilderInterface {
    *   The config to write.
    *
    * @return false|string
+   * @throws \Drupal\webpack\WebpackConfigWriteException
    */
   public function writeWebpackConfig($config);
 

--- a/src/WebpackDrushCommands.php
+++ b/src/WebpackDrushCommands.php
@@ -9,6 +9,7 @@ use Drupal\Core\Extension\ThemeHandlerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\npm\Exception\NpmCommandFailedException;
 use Drush\Commands\DrushCommands;
 
 /**
@@ -57,6 +58,8 @@ class WebpackDrushCommands extends DrushCommands {
       $this->output()->writeln($e->getMessage());
     } catch (WebpackConfigWriteException $e) {
       $this->output()->writeln($e->getMessage());
+    } catch (NpmCommandFailedException $e) {
+      $this->output()->writeln("The npm script has failed. Details:\n{$e->getMessage()}");
     } finally {
       $this->output()->writeln($this->t(
         'Build :status',
@@ -77,14 +80,18 @@ class WebpackDrushCommands extends DrushCommands {
    * @usage drush wepback:serve
    *   Serve the js files.
    */
-  public function serve($options = ['port' => '8080']) {
+  public function serve($options = ['port' => '1234']) {
     $this->output()->writeln('Hey! Starting the dev server.');
     try {
-      $this->bundler->serve($options['port']);
+      $this->bundler->serve($options['port'], function ($type, $buffer) {
+        $this->output()->writeln($buffer);
+      });
     } catch (WebpackConfigNotValidException $e) {
       $this->output()->writeln($e->getMessage());
     } catch (WebpackConfigWriteException $e) {
       $this->output()->writeln($e->getMessage());
+    } catch (NpmCommandFailedException $e) {
+      $this->output()->writeln("The npm script has failed. Details:\n{$e->getMessage()}");
     }
   }
 

--- a/tests/modules/webpack_test_libs/config/install/webpack.settings.yml
+++ b/tests/modules/webpack_test_libs/config/install/webpack.settings.yml
@@ -1,1 +1,0 @@
-output_path: "sites/default/files"

--- a/tests/modules/webpack_test_libs/src/WebpackTestLibsServiceProvider.php
+++ b/tests/modules/webpack_test_libs/src/WebpackTestLibsServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\webpack_test_libs;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+
+class WebpackTestLibsServiceProvider implements ServiceModifierInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    $container->removeDefinition('test.http_client.middleware');
+  }
+}

--- a/tests/modules/webpack_test_libs/webpack_test_libs.install
+++ b/tests/modules/webpack_test_libs/webpack_test_libs.install
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * Implements hook_install().
+ */
+function webpack_test_libs_install() {
+  \Drupal::configFactory()
+    ->getEditable('webpack.settings')
+    ->set('output_path', 'sites/default/files')
+    ->save();
+}

--- a/tests/src/Kernel/BundlerTest.php
+++ b/tests/src/Kernel/BundlerTest.php
@@ -3,6 +3,9 @@
 namespace Drupal\Tests\webpack\Kernel;
 
 use Drupal\npm\Exception\NpmCommandFailedException;
+use Drupal\webpack\WebpackConfigNotValidException;
+use Drupal\webpack\WebpackConfigWriteException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
 
 class BundlerTest extends WebpackTestBase {
 
@@ -23,6 +26,35 @@ class BundlerTest extends WebpackTestBase {
     $messages = implode("\n", $messages);
     foreach ($bundleMapping as $entryPoint => $files) {
       $this->assertRegExp("/Entrypoint $entryPoint/", $messages, 'Expected entrypoint found in the messages.');
+    }
+  }
+
+  public function testServe() {
+    system('pkill node');
+    $bundler = $this->bundler;
+    $counter = 0;
+
+    $this->assertNull($bundler->getServePort(), 'Serve port is null initially.');
+
+    $outputListener = function ($type, $buffer) use ($bundler, &$counter) {
+      if ($counter++ == 2) {
+        // In the third chunk of output we expect the port to be set and
+        // the bundles to be reachable.
+        $port = $bundler->getServePort();
+        $this->assertNotEmpty($bundler->getServePort(), 'Serve port has been saved.');
+
+        $client = \Drupal::httpClient();
+        foreach ($this->librariesInspector->getEntryPoints() as $id => $path) {
+          $response = $client->get("http://localhost:$port/$id.bundle.js");
+          $this->assertEquals(200, $response->getStatusCode(), "Bundle $id is reachable on the dev server.");
+        }
+      }
+    };
+
+    try {
+      $this->bundler->serve(1234, $outputListener, 15);
+    } catch (ProcessTimedOutException $e) {
+      // The process is expected to time out.
     }
   }
 

--- a/tests/src/Kernel/WebpackTestBase.php
+++ b/tests/src/Kernel/WebpackTestBase.php
@@ -10,7 +10,7 @@ abstract class WebpackTestBase extends KernelTestBase {
   protected static $modules = ['npm', 'system', 'webpack', 'webpack_test_libs'];
 
   /**
-   * @var \Drupal\npm\Plugin\NpmExecutableInterface
+   * @var \Drupal\npm\NpmExecutableInterface
    */
   protected $npmExecutable;
 
@@ -44,16 +44,17 @@ abstract class WebpackTestBase extends KernelTestBase {
     $this->installConfig('webpack_test_libs');
     $this->installConfig('system');
 
-    $process = $this->npmExecutable->initPackageJson();
-//    throw new \Exception($process->getOutput() . $process->getErrorOutput());
+    // Run the install hook manually. It'll set some webpack config.
+    \module_load_include('install', 'webpack_test_libs');
+    \webpack_test_libs_install();
+
+    $this->npmExecutable->initPackageJson();
 
     // Add webpack dependencies.
-    $process = $this->npmExecutable->addPackages(['webpack', 'webpack-cli', 'webpack-serve', 'ramda']);
-//    throw new \Exception($process->getOutput() . $process->getErrorOutput());
-    // And the test libs.
-//    $this->npmExecutable->addPackages(['apollo-boost', 'ramda']);
+    $this->npmExecutable->addPackages(['webpack', 'webpack-cli', 'webpack-serve']);
 
-    // TODO: Create package.json and install dependencies.
+    // And the test libs.
+    $this->npmExecutable->addPackages(['ramda']);
   }
 
 }


### PR DESCRIPTION
Implemented WebpackTestBase for kernel tests. Changed the default serve port to 1234. Added  and  parameters to the serve function. Made serve use npm's runScript instead of relying on a home-grown command execution. Changed the way webpack_test_libs installs its config. Implemented WebpackTestLibsServiceProvider to work around #2571475. Updated the error reporting in drush commands. Moved getEntryPoints from webpackConfigBuilder to librariesInspector. Made getAllLibraries protected.